### PR TITLE
chore: fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Activate your virtual environment by running the following command:
 source venv/bin/activate
 
 # windows
-.\env\Scripts\activate
+.\venv\Scripts\activate
 ```
 
 Install the [bugsplat](https://pypi.org/project/bugsplat) package using pip:


### PR DESCRIPTION
### Description

Creates a venv folder not env folder.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
